### PR TITLE
Fixed AreaTarget bug where it only considered caster

### DIFF
--- a/src/main/java/com/sucy/skill/dynamic/target/AreaTarget.java
+++ b/src/main/java/com/sucy/skill/dynamic/target/AreaTarget.java
@@ -52,7 +52,7 @@ public class AreaTarget extends TargetComponent {
 
         final double radius = parseValues(caster, RADIUS, level, 3.0);
         final boolean random = settings.getBool(RANDOM, false);
-        return determineTargets(caster, level, targets, t -> shuffle(Nearby.getLivingNearby(caster, radius), random));
+        return determineTargets(caster, level, targets, t -> shuffle(Nearby.getLivingNearby(t, radius), random));
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
There was a bug in AreaTarget where only the caster was being considered. This bug was reported by Loonmight in the G.E.A.R.S. Discord.